### PR TITLE
Make getter methods more consistent

### DIFF
--- a/cloudfoundry-client-lib/pom.xml
+++ b/cloudfoundry-client-lib/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cloudfoundry-client-lib</artifactId>
@@ -49,8 +48,8 @@
                         </configuration>
                     </plugin>
 
-                    <!-- Used to syntactically verify our byteman rules that 
-                        detect unexpected direct sockets not going through proxy -->
+                    <!-- Used to syntactically verify our byteman rules that detect unexpected direct sockets not going through 
+                        proxy -->
                     <plugin>
                         <groupId>org.jboss.byteman</groupId>
                         <artifactId>byteman-rulecheck-maven-plugin</artifactId>
@@ -140,9 +139,8 @@
             </dependencies>
         </profile>
 
-        <!-- tools classes are needed by byteman, and their path is system-dependent, 
-            one of those profiles will be active, in addition to profile controlling 
-            which tests are executed -->
+        <!-- tools classes are needed by byteman, and their path is system-dependent, one of those profiles will be active, 
+            in addition to profile controlling which tests are executed -->
         <profile>
             <!-- normally tools jar is in ../lib/tools.jar -->
             <id>default-toolsjar-profile</id>
@@ -322,6 +320,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -346,6 +345,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/cloudfoundry-client-lib/pom.xml
+++ b/cloudfoundry-client-lib/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.sap.cloud.lm.sl</groupId>
         <artifactId>cf-java-client</artifactId>
-        <version>1.1.4.RELEASE-sap-04-SNAPSHOT</version>
+        <version>1.1.4.RELEASE-sap-04</version>
     </parent>
 
     <properties>

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -167,10 +167,12 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         this.cc = cc;
     }
 
+    @Override
     public void addDomain(String domainName) {
         cc.addDomain(domainName);
     }
 
+    @Override
     public void addRoute(String host, String domainName) {
         cc.addRoute(host, domainName);
     }
@@ -230,6 +232,7 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         cc.bindSecurityGroup(orgName, spaceName, securityGroupName);
     }
 
+    @Override
     public void bindService(String appName, String serviceName) {
         cc.bindService(appName, serviceName);
     }
@@ -239,15 +242,18 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         cc.bindStagingSecurityGroup(securityGroupName);
     }
 
+    @Override
     public void createApplication(String appName, Staging staging, Integer memory, List<String> uris, List<String> serviceNames) {
         cc.createApplication(appName, staging, memory, uris, serviceNames);
     }
 
+    @Override
     public void createApplication(String appName, Staging staging, Integer disk, Integer memory, List<String> uris,
         List<String> serviceNames) {
         cc.createApplication(appName, staging, disk, memory, uris, serviceNames);
     }
 
+    @Override
     public void createQuota(CloudQuota quota) {
         cc.createQuota(quota);
     }
@@ -262,10 +268,12 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         cc.createSecurityGroup(name, jsonRulesFile);
     }
 
+    @Override
     public void createService(CloudService service) {
         cc.createService(service);
     }
 
+    @Override
     public void createServiceBroker(CloudServiceBroker serviceBroker) {
         cc.createServiceBroker(serviceBroker);
     }
@@ -275,30 +283,37 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         cc.createSpace(spaceName);
     }
 
+    @Override
     public void createUserProvidedService(CloudService service, Map<String, Object> credentials) {
         cc.createUserProvidedService(service, credentials);
     }
 
+    @Override
     public void createUserProvidedService(CloudService service, Map<String, Object> credentials, String syslogDrainUrl) {
         cc.createUserProvidedService(service, credentials, syslogDrainUrl);
     }
 
+    @Override
     public void debugApplication(String appName, DebugMode mode) {
         cc.debugApplication(appName, mode);
     }
 
+    @Override
     public void deleteAllApplications() {
         cc.deleteAllApplications();
     }
 
+    @Override
     public void deleteAllServices() {
         cc.deleteAllServices();
     }
 
+    @Override
     public void deleteApplication(String appName) {
         cc.deleteApplication(appName);
     }
 
+    @Override
     public void deleteDomain(String domainName) {
         cc.deleteDomain(domainName);
     }
@@ -308,10 +323,12 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         return cc.deleteOrphanedRoutes();
     }
 
+    @Override
     public void deleteQuota(String quotaName) {
         cc.deleteQuota(quotaName);
     }
 
+    @Override
     public void deleteRoute(String host, String domainName) {
         cc.deleteRoute(host, domainName);
     }
@@ -321,6 +338,7 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         cc.deleteSecurityGroup(securityGroupName);
     }
 
+    @Override
     public void deleteService(String service) {
         cc.deleteService(service);
     }
@@ -335,54 +353,67 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         cc.deleteSpace(spaceName);
     }
 
+    @Override
     public CloudApplication getApplication(String appName) {
         return cc.getApplication(appName);
     }
 
+    @Override
     public CloudApplication getApplication(String appName, boolean required) {
         return cc.getApplication(appName, required);
     }
 
+    @Override
     public CloudApplication getApplication(UUID appGuid) {
         return cc.getApplication(appGuid);
     }
 
+    @Override
     public CloudApplication getApplication(UUID appGuid, boolean required) {
         return cc.getApplication(appGuid, required);
     }
 
+    @Override
     public Map<String, Object> getApplicationEnvironment(UUID appGuid) {
         return cc.getApplicationEnvironment(appGuid);
     }
 
+    @Override
     public Map<String, Object> getApplicationEnvironment(String appName) {
         return cc.getApplicationEnvironment(appName);
     }
 
+    @Override
     public List<CloudEvent> getApplicationEvents(String appName) {
         return cc.getApplicationEvents(appName);
     }
 
+    @Override
     public InstancesInfo getApplicationInstances(String appName) {
         return cc.getApplicationInstances(appName);
     }
 
+    @Override
     public InstancesInfo getApplicationInstances(CloudApplication app) {
         return cc.getApplicationInstances(app);
     }
 
+    @Override
     public ApplicationStats getApplicationStats(String appName) {
         return cc.getApplicationStats(appName);
     }
 
+    @Override
     public List<CloudApplication> getApplications() {
         return cc.getApplications();
     }
 
+    @Override
     public URL getCloudControllerUrl() {
         return cc.getCloudControllerUrl();
     }
 
+    @Override
     public CloudInfo getCloudInfo() {
         if (info == null) {
             info = cc.getInfo();
@@ -393,39 +424,48 @@ public class CloudFoundryClient implements CloudFoundryOperations {
     /**
      * @deprecated use {@link #streamLogs(String, ApplicationLogListener)} or {@link #getRecentLogs(String)}
      */
+    @Override
     public Map<String, String> getCrashLogs(String appName) {
         return cc.getCrashLogs(appName);
     }
 
+    @Override
     public CrashesInfo getCrashes(String appName) {
         return cc.getCrashes(appName);
     }
 
+    @Override
     public CloudDomain getDefaultDomain() {
         return cc.getDefaultDomain();
     }
 
+    @Override
     public List<CloudDomain> getDomains() {
         return cc.getDomains();
     }
 
+    @Override
     public List<CloudDomain> getDomainsForOrg() {
         return cc.getDomainsForOrg();
     }
 
+    @Override
     public List<CloudEvent> getEvents() {
         return cc.getEvents();
     }
 
+    @Override
     public String getFile(String appName, int instanceIndex, String filePath) {
         return cc.getFile(appName, instanceIndex, filePath, 0, -1);
     }
 
+    @Override
     public String getFile(String appName, int instanceIndex, String filePath, int startPosition) {
         Assert.isTrue(startPosition >= 0, startPosition + " is not a valid value for start position, it should be 0 or greater.");
         return cc.getFile(appName, instanceIndex, filePath, startPosition, -1);
     }
 
+    @Override
     public String getFile(String appName, int instanceIndex, String filePath, int startPosition, int endPosition) {
         Assert.isTrue(startPosition >= 0, startPosition + " is not a valid value for start position, it should be 0 or greater.");
         Assert.isTrue(endPosition > startPosition, endPosition
@@ -435,6 +475,7 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 
     // list services, un/provision services, modify instance
 
+    @Override
     public String getFileTail(String appName, int instanceIndex, String filePath, int length) {
         Assert.isTrue(length > 0, length + " is not a valid value for length, it should be 1 or greater.");
         return cc.getFile(appName, instanceIndex, filePath, -1, length);
@@ -443,14 +484,17 @@ public class CloudFoundryClient implements CloudFoundryOperations {
     /**
      * @deprecated use {@link #streamLogs(String, ApplicationLogListener)} or {@link #getRecentLogs(String)}
      */
+    @Override
     public Map<String, String> getLogs(String appName) {
         return cc.getLogs(appName);
     }
 
+    @Override
     public CloudOrganization getOrganization(String orgName) {
         return cc.getOrganization(orgName);
     }
 
+    @Override
     public CloudOrganization getOrganization(String orgName, boolean required) {
         return cc.getOrganization(orgName, required);
     }
@@ -460,30 +504,37 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         return cc.getOrganizationUsers(orgName);
     }
 
+    @Override
     public List<CloudOrganization> getOrganizations() {
         return cc.getOrganizations();
     }
 
+    @Override
     public List<CloudDomain> getPrivateDomains() {
         return cc.getPrivateDomains();
     }
 
+    @Override
     public CloudQuota getQuota(String quotaName) {
         return cc.getQuota(quotaName);
     }
 
+    @Override
     public CloudQuota getQuota(String quotaName, boolean required) {
         return cc.getQuota(quotaName, required);
     }
 
+    @Override
     public List<CloudQuota> getQuotas() {
         return cc.getQuotas();
     }
 
+    @Override
     public List<ApplicationLog> getRecentLogs(String appName) {
         return cc.getRecentLogs(appName);
     }
 
+    @Override
     public List<CloudRoute> getRoutes(String domainName) {
         return cc.getRoutes(domainName);
     }
@@ -508,42 +559,52 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         return cc.getSecurityGroups();
     }
 
+    @Override
     public CloudService getService(String service) {
         return cc.getService(service);
     }
 
+    @Override
     public CloudService getService(String service, boolean required) {
         return cc.getService(service, required);
     }
 
+    @Override
     public CloudServiceBroker getServiceBroker(String name) {
         return cc.getServiceBroker(name);
     }
 
+    @Override
     public CloudServiceBroker getServiceBroker(String name, boolean required) {
         return cc.getServiceBroker(name, required);
     }
 
+    @Override
     public List<CloudServiceBroker> getServiceBrokers() {
         return cc.getServiceBrokers();
     }
 
+    @Override
     public CloudServiceInstance getServiceInstance(String service) {
         return cc.getServiceInstance(service);
     }
 
+    @Override
     public CloudServiceInstance getServiceInstance(String service, boolean required) {
         return cc.getServiceInstance(service, required);
     }
 
+    @Override
     public List<CloudServiceOffering> getServiceOfferings() {
         return cc.getServiceOfferings();
     }
 
+    @Override
     public List<CloudService> getServices() {
         return cc.getServices();
     }
 
+    @Override
     public List<CloudDomain> getSharedDomains() {
         return cc.getSharedDomains();
     }
@@ -588,6 +649,7 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         return cc.getSpaceManagers(orgName, spaceName);
     }
 
+    @Override
     public List<CloudSpace> getSpaces() {
         return cc.getSpaces();
     }
@@ -597,18 +659,22 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         return cc.getSpacesBoundToSecurityGroup(securityGroupName);
     }
 
+    @Override
     public CloudStack getStack(String name) {
         return cc.getStack(name);
     }
 
+    @Override
     public CloudStack getStack(String name, boolean required) {
         return cc.getStack(name, required);
     }
 
+    @Override
     public List<CloudStack> getStacks() {
         return cc.getStacks();
     }
 
+    @Override
     public String getStagingLogs(StartingInfo info, int offset) {
         return cc.getStagingLogs(info, offset);
     }
@@ -618,58 +684,72 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         return cc.getStagingSecurityGroups();
     }
 
+    @Override
     public OAuth2AccessToken login() {
         return cc.login();
     }
 
+    @Override
     public void logout() {
         cc.logout();
     }
 
+    @Override
     public void openFile(String appName, int instanceIndex, String filePath, ClientHttpResponseCallback callback) {
         cc.openFile(appName, instanceIndex, filePath, callback);
     }
 
+    @Override
     public void register(String email, String password) {
         cc.register(email, password);
     }
 
+    @Override
     public void registerRestLogListener(RestLogCallback callBack) {
         cc.registerRestLogListener(callBack);
     }
 
+    @Override
     public void removeDomain(String domainName) {
         cc.removeDomain(domainName);
     }
 
+    @Override
     public void rename(String appName, String newName) {
         cc.rename(appName, newName);
     }
 
+    @Override
     public StartingInfo restartApplication(String appName) {
         return cc.restartApplication(appName);
     }
 
+    @Override
     public void setQuotaToOrg(String orgName, String quotaName) {
         cc.setQuotaToOrg(orgName, quotaName);
     }
 
+    @Override
     public void setResponseErrorHandler(ResponseErrorHandler errorHandler) {
         cc.setResponseErrorHandler(errorHandler);
     }
 
+    @Override
     public StartingInfo startApplication(String appName) {
         return cc.startApplication(appName);
     }
 
+    @Override
     public void stopApplication(String appName) {
         cc.stopApplication(appName);
     }
 
+    @Override
     public StreamingLogToken streamLogs(String appName, ApplicationLogListener listener) {
         return cc.streamLogs(appName, listener);
     }
 
+    @Override
     public void unRegisterRestLogListener(RestLogCallback callBack) {
         cc.unRegisterRestLogListener(callBack);
     }
@@ -684,6 +764,7 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         cc.unbindSecurityGroup(orgName, spaceName, securityGroupName);
     }
 
+    @Override
     public void unbindService(String appName, String serviceName) {
         cc.unbindService(appName, serviceName);
     }
@@ -693,50 +774,62 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         cc.unbindStagingSecurityGroup(securityGroupName);
     }
 
+    @Override
     public void unregister() {
         cc.unregister();
     }
 
+    @Override
     public void updateApplicationDiskQuota(String appName, int disk) {
         cc.updateApplicationDiskQuota(appName, disk);
     }
 
+    @Override
     public void updateApplicationEnv(String appName, Map<String, String> env) {
         cc.updateApplicationEnv(appName, env);
     }
 
+    @Override
     public void updateApplicationEnv(String appName, List<String> env) {
         cc.updateApplicationEnv(appName, env);
     }
 
+    @Override
     public void updateApplicationInstances(String appName, int instances) {
         cc.updateApplicationInstances(appName, instances);
     }
 
+    @Override
     public void updateApplicationMemory(String appName, int memory) {
         cc.updateApplicationMemory(appName, memory);
     }
 
+    @Override
     public void updateApplicationServices(String appName, List<String> services) {
         cc.updateApplicationServices(appName, services);
     }
 
+    @Override
     public void updateApplicationStaging(String appName, Staging staging) {
         cc.updateApplicationStaging(appName, staging);
     }
 
+    @Override
     public void updateApplicationUris(String appName, List<String> uris) {
         cc.updateApplicationUris(appName, uris);
     }
 
+    @Override
     public void updatePassword(String newPassword) {
         cc.updatePassword(newPassword);
     }
 
+    @Override
     public void updatePassword(CloudCredentials credentials, String newPassword) {
         cc.updatePassword(credentials, newPassword);
     }
 
+    @Override
     public void updateQuota(CloudQuota quota, String name) {
         cc.updateQuota(quota, name);
     }
@@ -751,6 +844,7 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         cc.updateSecurityGroup(name, jsonRulesFile);
     }
 
+    @Override
     public void updateServiceBroker(CloudServiceBroker serviceBroker) {
         cc.updateServiceBroker(serviceBroker);
     }
@@ -760,31 +854,38 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         cc.updateServicePlanVisibilityForBroker(name, visibility);
     }
 
+    @Override
     public void uploadApplication(String appName, String file) throws IOException {
         cc.uploadApplication(appName, new File(file), null);
     }
 
+    @Override
     public void uploadApplication(String appName, File file) throws IOException {
         cc.uploadApplication(appName, file, null);
     }
 
+    @Override
     public void uploadApplication(String appName, File file, UploadStatusCallback callback) throws IOException {
         cc.uploadApplication(appName, file, callback);
     }
 
+    @Override
     public void uploadApplication(String appName, String fileName, InputStream inputStream) throws IOException {
         cc.uploadApplication(appName, fileName, inputStream, null);
     }
 
+    @Override
     public void uploadApplication(String appName, String fileName, InputStream inputStream, UploadStatusCallback callback)
         throws IOException {
         cc.uploadApplication(appName, fileName, inputStream, callback);
     }
 
+    @Override
     public void uploadApplication(String appName, ApplicationArchive archive) throws IOException {
         cc.uploadApplication(appName, archive, null);
     }
 
+    @Override
     public void uploadApplication(String appName, ApplicationArchive archive, UploadStatusCallback callback) throws IOException {
         cc.uploadApplication(appName, archive, callback);
     }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -339,8 +339,16 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         return cc.getApplication(appName);
     }
 
+    public CloudApplication getApplication(String appName, boolean required) {
+        return cc.getApplication(appName, required);
+    }
+
     public CloudApplication getApplication(UUID appGuid) {
         return cc.getApplication(appGuid);
+    }
+
+    public CloudApplication getApplication(UUID appGuid, boolean required) {
+        return cc.getApplication(appGuid, required);
     }
 
     public Map<String, Object> getApplicationEnvironment(UUID appGuid) {
@@ -439,6 +447,10 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         return cc.getLogs(appName);
     }
 
+    public CloudOrganization getOrganization(String orgName) {
+        return cc.getOrganization(orgName);
+    }
+
     public CloudOrganization getOrganization(String orgName, boolean required) {
         return cc.getOrganization(orgName, required);
     }
@@ -454,6 +466,10 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 
     public List<CloudDomain> getPrivateDomains() {
         return cc.getPrivateDomains();
+    }
+
+    public CloudQuota getQuota(String quotaName) {
+        return cc.getQuota(quotaName);
     }
 
     public CloudQuota getQuota(String quotaName, boolean required) {
@@ -483,6 +499,11 @@ public class CloudFoundryClient implements CloudFoundryOperations {
     }
 
     @Override
+    public CloudSecurityGroup getSecurityGroup(String securityGroupName, boolean required) {
+        return cc.getSecurityGroup(securityGroupName, required);
+    }
+
+    @Override
     public List<CloudSecurityGroup> getSecurityGroups() {
         return cc.getSecurityGroups();
     }
@@ -491,8 +512,16 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         return cc.getService(service);
     }
 
+    public CloudService getService(String service, boolean required) {
+        return cc.getService(service, required);
+    }
+
     public CloudServiceBroker getServiceBroker(String name) {
         return cc.getServiceBroker(name);
+    }
+
+    public CloudServiceBroker getServiceBroker(String name, boolean required) {
+        return cc.getServiceBroker(name, required);
     }
 
     public List<CloudServiceBroker> getServiceBrokers() {
@@ -501,6 +530,10 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 
     public CloudServiceInstance getServiceInstance(String service) {
         return cc.getServiceInstance(service);
+    }
+
+    public CloudServiceInstance getServiceInstance(String service, boolean required) {
+        return cc.getServiceInstance(service, required);
     }
 
     public List<CloudServiceOffering> getServiceOfferings() {
@@ -518,6 +551,11 @@ public class CloudFoundryClient implements CloudFoundryOperations {
     @Override
     public CloudSpace getSpace(String spaceName) {
         return cc.getSpace(spaceName);
+    }
+
+    @Override
+    public CloudSpace getSpace(String spaceName, boolean required) {
+        return cc.getSpace(spaceName, required);
     }
 
     @Override
@@ -561,6 +599,10 @@ public class CloudFoundryClient implements CloudFoundryOperations {
 
     public CloudStack getStack(String name) {
         return cc.getStack(name);
+    }
+
+    public CloudStack getStack(String name, boolean required) {
+        return cc.getStack(name, required);
     }
 
     public List<CloudStack> getStacks() {
@@ -746,4 +788,5 @@ public class CloudFoundryClient implements CloudFoundryOperations {
     public void uploadApplication(String appName, ApplicationArchive archive, UploadStatusCallback callback) throws IOException {
         cc.uploadApplication(appName, archive, callback);
     }
+
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryClient.java
@@ -439,8 +439,8 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         return cc.getLogs(appName);
     }
 
-    public CloudOrganization getOrgByName(String orgName, boolean required) {
-        return cc.getOrgByName(orgName, required);
+    public CloudOrganization getOrganization(String orgName, boolean required) {
+        return cc.getOrganization(orgName, required);
     }
 
     @Override
@@ -456,8 +456,8 @@ public class CloudFoundryClient implements CloudFoundryOperations {
         return cc.getPrivateDomains();
     }
 
-    public CloudQuota getQuotaByName(String quotaName, boolean required) {
-        return cc.getQuotaByName(quotaName, required);
+    public CloudQuota getQuota(String quotaName, boolean required) {
+        return cc.getQuota(quotaName, required);
     }
 
     public List<CloudQuota> getQuotas() {

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -386,12 +386,30 @@ public interface CloudFoundryOperations {
     CloudApplication getApplication(String appName);
 
     /**
+     * Get cloud application with the specified name.
+     *
+     * @param appName name of the app
+     * @param required if true, and organization is not found, throw an exception
+     * @return the cloud application
+     */
+    CloudApplication getApplication(String appName, boolean required);
+
+    /**
      * Get cloud application with the specified GUID.
      *
      * @param guid GUID of the app
      * @return the cloud application
      */
     CloudApplication getApplication(UUID guid);
+
+    /**
+     * Get cloud application with the specified GUID.
+     *
+     * @param guid GUID of the app
+     * @param required if true, and organization is not found, throw an exception
+     * @return the cloud application
+     */
+    CloudApplication getApplication(UUID guid, boolean required);
 
     /**
      * Get application environment variables for the app with the specified name.
@@ -569,6 +587,14 @@ public interface CloudFoundryOperations {
      * Get the organization with the specified name.
      *
      * @param orgName name of organization
+     * @return
+     */
+    CloudOrganization getOrganization(String orgName);
+
+    /**
+     * Get the organization with the specified name.
+     *
+     * @param orgName name of organization
      * @param required if true, and organization is not found, throw an exception
      * @return
      */
@@ -601,7 +627,15 @@ public interface CloudFoundryOperations {
      * Get quota by name
      *
      * @param quotaName
-     * @param required
+     * @return CloudQuota instance
+     */
+    CloudQuota getQuota(String quotaName);
+
+    /**
+     * Get quota by name
+     *
+     * @param quotaName
+     * @param required if true, and organization is not found, throw an exception
      * @return CloudQuota instance
      */
     CloudQuota getQuota(String quotaName, boolean required);
@@ -649,6 +683,17 @@ public interface CloudFoundryOperations {
     CloudSecurityGroup getSecurityGroup(String securityGroupName);
 
     /**
+     * Get a specific security group by name.
+     * <p/>
+     * This method requires the logged in user to have admin permissions in the cloud controller.
+     *
+     * @param securityGroupName The name of the security group
+     * @param required if true, and organization is not found, throw an exception
+     * @return the CloudSecurityGroup or <code>null</code> if no security groups exist with the given name
+     */
+    CloudSecurityGroup getSecurityGroup(String securityGroupName, boolean required);
+
+    /**
      * Get a List of all application security groups.
      * <p/>
      * This method requires the logged in user to have admin permissions in the cloud controller.
@@ -666,12 +711,30 @@ public interface CloudFoundryOperations {
     CloudService getService(String service);
 
     /**
+     * Get cloud service.
+     *
+     * @param service name of service
+     * @param required if true, and organization is not found, throw an exception
+     * @return the cloud service info
+     */
+    CloudService getService(String service, boolean required);
+
+    /**
      * Get a service broker.
      *
      * @param name the service broker name
      * @return the service broker
      */
     CloudServiceBroker getServiceBroker(String name);
+
+    /**
+     * Get a service broker.
+     *
+     * @param name the service broker name
+     * @param required if true, and organization is not found, throw an exception
+     * @return the service broker
+     */
+    CloudServiceBroker getServiceBroker(String name, boolean required);
 
     /**
      * Get all service brokers.
@@ -687,6 +750,15 @@ public interface CloudFoundryOperations {
      * @return the service instance info
      */
     CloudServiceInstance getServiceInstance(String service);
+
+    /**
+     * Get a service instance.
+     *
+     * @param service name of the service instance
+     * @param required if true, and organization is not found, throw an exception
+     * @return the service instance info
+     */
+    CloudServiceInstance getServiceInstance(String service, boolean required);
 
     /**
      * Get all service offerings.
@@ -716,6 +788,15 @@ public interface CloudFoundryOperations {
      * @return the cloud space
      */
     CloudSpace getSpace(String spaceName);
+
+    /**
+     * Get space name with the specified name.
+     *
+     * @param spaceName name of the space
+     * @param required if true, and organization is not found, throw an exception
+     * @return the cloud space
+     */
+    CloudSpace getSpace(String spaceName, boolean required);
 
     /**
      * Get list of space auditor UUID for the space.
@@ -789,6 +870,15 @@ public interface CloudFoundryOperations {
      * @return the stack
      */
     CloudStack getStack(String name);
+
+    /**
+     * Get a stack by name.
+     *
+     * @param name the name of the stack to get
+     * @param required if true, and organization is not found, throw an exception
+     * @return the stack, or null if not found
+     */
+    CloudStack getStack(String name, boolean required);
 
     /**
      * Get the list of stacks available for staging applications.

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -165,7 +165,7 @@ public interface CloudFoundryOperations {
      * @param orgName The name of the organization that the space is in.
      * @param spaceName The name of the space
      * @param securityGroupName The name of the security group to bind to the space
-     * @throws IllegalArgumentException if the org, space, or security group do not exist
+     * @throws CloudFoundryException if the org, space, or security group do not exist
      */
     void bindSecurityGroup(String orgName, String spaceName, String securityGroupName);
 
@@ -352,7 +352,7 @@ public interface CloudFoundryOperations {
      * This method requires the logged in user to have admin permissions in the cloud controller.
      *
      * @param securityGroupName
-     * @throws IllegalArgumentException if a security group does not exist with the given name
+     * @throws CloudFoundryException if a security group does not exist with the given name
      */
     void deleteSecurityGroup(String securityGroupName);
 
@@ -579,7 +579,7 @@ public interface CloudFoundryOperations {
      *
      * @param orgName organization name
      * @return a Map CloudUser with username as key
-     * @throws IllegalArgumentException if the org do not exist
+     * @throws CloudFoundryException if the org do not exist
      */
     Map<String, CloudUser> getOrganizationUsers(String orgName);
 
@@ -644,7 +644,7 @@ public interface CloudFoundryOperations {
      * This method requires the logged in user to have admin permissions in the cloud controller.
      *
      * @param securityGroupName The name of the security group
-     * @return the CloudSecurityGroup or <code>null</code> if no security groups exist with the given name
+     * @return the CloudSecurityGroup
      */
     CloudSecurityGroup getSecurityGroup(String securityGroupName);
 
@@ -786,7 +786,7 @@ public interface CloudFoundryOperations {
      * Get a stack by name.
      *
      * @param name the name of the stack to get
-     * @return the stack, or null if not found
+     * @return the stack
      */
     CloudStack getStack(String name);
 
@@ -939,7 +939,7 @@ public interface CloudFoundryOperations {
      * @param orgName The name of the organization that the space is in.
      * @param spaceName The name of the space
      * @param securityGroupName The name of the security group to bind to the space
-     * @throws IllegalArgumentException if the org, space, or security group do not exist
+     * @throws CloudFoundryException if the org, space, or security group do not exist
      */
     void unbindSecurityGroup(String orgName, String spaceName, String securityGroupName);
 
@@ -1057,7 +1057,7 @@ public interface CloudFoundryOperations {
      * This method requires the logged in user to have admin permissions in the cloud controller.
      *
      * @param securityGroup
-     * @throws IllegalArgumentException if a security group does not exist with the name of the given CloudSecurityGroup
+     * @throws CloudFoundryException if a security group does not exist with the name of the given CloudSecurityGroup
      */
     void updateSecurityGroup(CloudSecurityGroup securityGroup);
 
@@ -1088,7 +1088,7 @@ public interface CloudFoundryOperations {
      * This method requires the logged in user to have admin permissions in the cloud controller.
      *
      * @param jsonRulesFile An input stream that has a single array with JSON objects inside describing the rules
-     * @throws IllegalArgumentException if a security group does not exist with the given name
+     * @throws CloudFoundryException if a security group does not exist with the given name
      * @see http://docs.cloudfoundry.org/adminguide/app-sec-groups.html
      */
     void updateSecurityGroup(String name, InputStream jsonRulesFile);

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudFoundryOperations.java
@@ -572,7 +572,7 @@ public interface CloudFoundryOperations {
      * @param required if true, and organization is not found, throw an exception
      * @return
      */
-    CloudOrganization getOrgByName(String orgName, boolean required);
+    CloudOrganization getOrganization(String orgName, boolean required);
 
     /**
      * Get all users in the specified organization
@@ -604,7 +604,7 @@ public interface CloudFoundryOperations {
      * @param required
      * @return CloudQuota instance
      */
-    CloudQuota getQuotaByName(String quotaName, boolean required);
+    CloudQuota getQuota(String quotaName, boolean required);
 
     /**
      * Get quota definitions

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
@@ -82,11 +82,9 @@ public interface CloudControllerClient {
 
     void bindStagingSecurityGroup(String securityGroupName);
 
-    void createApplication(String appName, Staging staging, Integer memory, List<String> uris,
-                           List<String> serviceNames);
+    void createApplication(String appName, Staging staging, Integer memory, List<String> uris, List<String> serviceNames);
 
-    void createApplication(String appName, Staging staging, Integer disk, Integer memory,
-                           List<String> uris, List<String> serviceNames);
+    void createApplication(String appName, Staging staging, Integer disk, Integer memory, List<String> uris, List<String> serviceNames);
 
     // Service methods
 
@@ -170,8 +168,7 @@ public interface CloudControllerClient {
 
     Map<String, String> getLogs(String appName);
 
-    // Quota operations
-    CloudOrganization getOrgByName(String orgName, boolean required);
+    CloudOrganization getOrganization(String orgName, boolean required);
 
     Map<String, CloudUser> getOrganizationUsers(String orgName);
 
@@ -179,7 +176,7 @@ public interface CloudControllerClient {
 
     List<CloudDomain> getPrivateDomains();
 
-    CloudQuota getQuotaByName(String quotaName, boolean required);
+    CloudQuota getQuota(String quotaName, boolean required);
 
     List<CloudQuota> getQuotas();
 
@@ -305,9 +302,7 @@ public interface CloudControllerClient {
 
     void uploadApplication(String appName, File file, UploadStatusCallback callback) throws IOException;
 
-    void uploadApplication(String appName, String fileName, InputStream inputStream, UploadStatusCallback callback)
-            throws IOException;
+    void uploadApplication(String appName, String fileName, InputStream inputStream, UploadStatusCallback callback) throws IOException;
 
-    void uploadApplication(String appName, ApplicationArchive archive, UploadStatusCallback callback) throws
-            IOException;
+    void uploadApplication(String appName, ApplicationArchive archive, UploadStatusCallback callback) throws IOException;
 }

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClient.java
@@ -132,7 +132,11 @@ public interface CloudControllerClient {
 
     CloudApplication getApplication(String appName);
 
+    CloudApplication getApplication(String appName, boolean required);
+
     CloudApplication getApplication(UUID appGuid);
+
+    CloudApplication getApplication(UUID appGuid, boolean required);
 
     Map<String, Object> getApplicationEnvironment(UUID appGuid);
 
@@ -168,6 +172,8 @@ public interface CloudControllerClient {
 
     Map<String, String> getLogs(String appName);
 
+    CloudOrganization getOrganization(String orgName);
+
     CloudOrganization getOrganization(String orgName, boolean required);
 
     Map<String, CloudUser> getOrganizationUsers(String orgName);
@@ -175,6 +181,8 @@ public interface CloudControllerClient {
     List<CloudOrganization> getOrganizations();
 
     List<CloudDomain> getPrivateDomains();
+
+    CloudQuota getQuota(String quotaName);
 
     CloudQuota getQuota(String quotaName, boolean required);
 
@@ -188,15 +196,23 @@ public interface CloudControllerClient {
 
     CloudSecurityGroup getSecurityGroup(String securityGroupName);
 
+    CloudSecurityGroup getSecurityGroup(String securityGroupName, boolean required);
+
     List<CloudSecurityGroup> getSecurityGroups();
 
     CloudService getService(String service);
 
+    CloudService getService(String service, boolean required);
+
     CloudServiceBroker getServiceBroker(String name);
+
+    CloudServiceBroker getServiceBroker(String name, boolean required);
 
     List<CloudServiceBroker> getServiceBrokers();
 
     CloudServiceInstance getServiceInstance(String serviceName);
+
+    CloudServiceInstance getServiceInstance(String serviceName, boolean required);
 
     List<CloudServiceOffering> getServiceOfferings();
 
@@ -207,6 +223,8 @@ public interface CloudControllerClient {
     // Space management
 
     CloudSpace getSpace(String spaceName);
+
+    CloudSpace getSpace(String spaceName, boolean required);
 
     List<UUID> getSpaceAuditors(String orgName, String spaceName);
 
@@ -221,6 +239,8 @@ public interface CloudControllerClient {
     List<CloudSpace> getSpacesBoundToSecurityGroup(String securityGroupName);
 
     CloudStack getStack(String name);
+
+    CloudStack getStack(String name, boolean required);
 
     List<CloudStack> getStacks();
 

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
@@ -428,7 +428,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
     }
 
     public void deleteQuota(String quotaName) {
-        CloudQuota quota = this.getQuotaByName(quotaName, true);
+        CloudQuota quota = this.getQuota(quotaName, true);
         String setPath = "/v2/quota_definitions/{quotaGuid}";
         Map<String, Object> setVars = new HashMap<String, Object>();
         setVars.put("quotaGuid", quota.getMeta().getGuid());
@@ -667,7 +667,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
      * @param required
      * @return CloudOrganization instance
      */
-    public CloudOrganization getOrgByName(String orgName, boolean required) {
+    public CloudOrganization getOrganization(String orgName, boolean required) {
         Map<String, Object> urlVars = new HashMap<String, Object>();
         String urlPath = "/v2/organizations?inline-relations-depth=1&q=name:{name}";
         urlVars.put("name", orgName);
@@ -688,7 +688,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
     @Override
     public Map<String, CloudUser> getOrganizationUsers(String orgName) {
         String urlPath = "/v2/organizations/{guid}/users";
-        CloudOrganization organization = getOrgByName(orgName, true);
+        CloudOrganization organization = getOrganization(orgName, true);
 
         UUID orgGuid = organization.getMeta().getGuid();
         Map<String, Object> urlVars = new HashMap<String, Object>();
@@ -726,7 +726,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
      * @param required
      * @return CloudQuota instance
      */
-    public CloudQuota getQuotaByName(String quotaName, boolean required) {
+    public CloudQuota getQuota(String quotaName, boolean required) {
         Map<String, Object> urlVars = new HashMap<String, Object>();
         String urlPath = "/v2/quota_definitions?q=name:{name}";
         urlVars.put("name", quotaName);
@@ -1078,8 +1078,8 @@ public class CloudControllerClientImpl implements CloudControllerClient {
      * @param quotaName
      */
     public void setQuotaToOrg(String orgName, String quotaName) {
-        CloudQuota quota = this.getQuotaByName(quotaName, true);
-        CloudOrganization org = this.getOrgByName(orgName, true);
+        CloudQuota quota = this.getQuota(quotaName, true);
+        CloudOrganization org = this.getOrganization(orgName, true);
 
         doSetQuotaToOrg(org.getMeta().getGuid(), quota.getMeta().getGuid());
     }
@@ -1301,7 +1301,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
     }
 
     public void updateQuota(CloudQuota quota, String name) {
-        CloudQuota oldQuota = this.getQuotaByName(name, true);
+        CloudQuota oldQuota = this.getQuota(name, true);
 
         String setPath = "/v2/quota_definitions/{quotaGuid}";
 
@@ -1567,7 +1567,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
     private void associateRoleWithSpace(String orgName, String spaceName, String userGuid, String urlPath) {
         assertSpaceProvided("associate roles");
 
-        CloudOrganization organization = (orgName == null ? sessionSpace.getOrganization() : getOrgByName(orgName, true));
+        CloudOrganization organization = (orgName == null ? sessionSpace.getOrganization() : getOrganization(orgName, true));
         UUID orgGuid = organization.getMeta().getGuid();
 
         UUID spaceGuid = getSpaceGuid(spaceName, orgGuid);
@@ -2305,7 +2305,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
     }
 
     private UUID getSpaceGuid(String orgName, String spaceName) {
-        CloudOrganization org = getOrgByName(orgName, true);
+        CloudOrganization org = getOrganization(orgName, true);
         return getSpaceGuid(spaceName, org.getMeta().getGuid());
     }
 
@@ -2318,7 +2318,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
         if (spaceName == null) {
             spaceGuid = sessionSpace.getMeta().getGuid();
         } else {
-            CloudOrganization organization = (orgName == null ? sessionSpace.getOrganization() : getOrgByName(orgName, true));
+            CloudOrganization organization = (orgName == null ? sessionSpace.getOrganization() : getOrganization(orgName, true));
             spaceGuid = getSpaceGuid(spaceName, organization.getMeta().getGuid());
         }
 

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerClientImpl.java
@@ -294,6 +294,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
      *
      * @param quota
      */
+    @Override
     public void createQuota(CloudQuota quota) {
         String setPath = "/v2/quota_definitions";
         HashMap<String, Object> setRequest = new HashMap<String, Object>();
@@ -427,6 +428,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
         return deletedCloudRoutes;
     }
 
+    @Override
     public void deleteQuota(String quotaName) {
         CloudQuota quota = this.getQuota(quotaName);
         String setPath = "/v2/quota_definitions/{quotaGuid}";
@@ -519,7 +521,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
     @Override
     public Map<String, Object> getApplicationEnvironment(UUID appGuid) {
         String url = getUrl("/v2/apps/{guid}/env");
-        Map<String, Object> urlVars = new HashMap();
+        Map<String, Object> urlVars = new HashMap<>();
         urlVars.put("guid", appGuid);
         String resp = restTemplate.getForObject(url, String.class, urlVars);
         return JsonUtil.convertJsonToMap(resp);
@@ -766,6 +768,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
         return quota;
     }
 
+    @Override
     public List<CloudQuota> getQuotas() {
         String urlPath = "/v2/quota_definitions";
         List<Map<String, Object>> resourceList = getAllResources(urlPath, null);
@@ -1150,6 +1153,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
      * @param orgName
      * @param quotaName
      */
+    @Override
     public void setQuotaToOrg(String orgName, String quotaName) {
         CloudQuota quota = this.getQuota(quotaName);
         CloudOrganization org = this.getOrganization(orgName);
@@ -1373,6 +1377,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
         }
     }
 
+    @Override
     public void updateQuota(CloudQuota quota, String name) {
         CloudQuota oldQuota = this.getQuota(name);
 
@@ -1882,10 +1887,12 @@ public class CloudControllerClientImpl implements CloudControllerClient {
         boolean supportsRanges;
         try {
             supportsRanges = getRestTemplate().execute(getUrl(urlPath), HttpMethod.HEAD, new RequestCallback() {
+                @Override
                 public void doWithRequest(ClientHttpRequest request) throws IOException {
                     request.getHeaders().set("Range", "bytes=0-");
                 }
             }, new ResponseExtractor<Boolean>() {
+                @Override
                 public Boolean extractData(ClientHttpResponse response) throws IOException {
                     return response.getStatusCode().equals(HttpStatus.PARTIAL_CONTENT);
                 }
@@ -2511,6 +2518,7 @@ public class CloudControllerClientImpl implements CloudControllerClient {
 
     private StreamingLogToken streamLoggregatorLogs(String appName, ApplicationLogListener listener, boolean recent) {
         ClientEndpointConfig.Configurator configurator = new ClientEndpointConfig.Configurator() {
+            @Override
             public void beforeRequest(Map<String, List<String>> headers) {
                 String authorizationHeader = oauthClient.getAuthorizationHeader();
                 if (authorizationHeader != null) {

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/CloudFoundryClientTest.java
@@ -296,18 +296,18 @@ public class CloudFoundryClientTest {
         CloudQuota cloudQuota = new CloudQuota(null, CCNG_QUOTA_NAME_TEST);
         connectedClient.createQuota(cloudQuota);
 
-        CloudQuota afterCreate = connectedClient.getQuotaByName(CCNG_QUOTA_NAME_TEST, true);
+        CloudQuota afterCreate = connectedClient.getQuota(CCNG_QUOTA_NAME_TEST, true);
         assertNotNull(afterCreate);
 
         // change quota mem to 10240
         afterCreate.setMemoryLimit(10240);
         connectedClient.updateQuota(afterCreate, CCNG_QUOTA_NAME_TEST);
-        CloudQuota afterUpdate = connectedClient.getQuotaByName(CCNG_QUOTA_NAME_TEST, true);
+        CloudQuota afterUpdate = connectedClient.getQuota(CCNG_QUOTA_NAME_TEST, true);
         assertEquals(10240, afterUpdate.getMemoryLimit());
 
         // delete the quota
         connectedClient.deleteQuota(CCNG_QUOTA_NAME_TEST);
-        CloudQuota afterDelete = connectedClient.getQuotaByName(CCNG_QUOTA_NAME_TEST, false);
+        CloudQuota afterDelete = connectedClient.getQuota(CCNG_QUOTA_NAME_TEST, false);
         assertNull(afterDelete);
     }
 
@@ -1614,7 +1614,7 @@ public class CloudFoundryClientTest {
         assumeTrue(CCNG_USER_IS_ADMIN);
 
         // get old quota to restore after test
-        CloudOrganization org = connectedClient.getOrgByName(CCNG_USER_ORG, true);
+        CloudOrganization org = connectedClient.getOrganization(CCNG_USER_ORG, true);
         CloudQuota oldQuota = org.getQuota();
 
         // create and set test_quota to org
@@ -1623,7 +1623,7 @@ public class CloudFoundryClientTest {
         connectedClient.setQuotaToOrg(CCNG_USER_ORG, CCNG_QUOTA_NAME_TEST);
 
         // get the bound quota of org
-        org = connectedClient.getOrgByName(CCNG_USER_ORG, true);
+        org = connectedClient.getOrganization(CCNG_USER_ORG, true);
         CloudQuota newQuota = org.getQuota();
 
         // bound quota should be equals to test_quota

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>cf-java-client</artifactId>
     <packaging>pom</packaging>
     <name>Cloud Foundry Java Client Parent</name>
-    <version>1.1.4.RELEASE-sap-04-SNAPSHOT</version>
+    <version>1.1.4.RELEASE-sap-04</version>
     <description>SAP fork of CF Java Client</description>
     <url>https://github.com/SAP/cf-java-client-sap</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.lm.sl</groupId>
     <artifactId>cf-java-client</artifactId>
@@ -8,6 +9,10 @@
     <version>1.1.4.RELEASE-sap-04-SNAPSHOT</version>
     <description>SAP fork of CF Java Client</description>
     <url>https://github.com/SAP/cf-java-client-sap</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <modules>
         <module>cloudfoundry-client-lib</module>
@@ -30,30 +35,72 @@
         <connection>scm:git:https://github.com/SAP/cf-java-client-sap.git</connection>
         <developerConnection>scm:git:https://github.com/SAP/cf-java-client-sap.git</developerConnection>
         <url>https://github.com/SAP/cf-java-client-sap.git</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <developers>
         <developer>
             <id>nvvalchev</id>
             <name>Nikolay Valchev</name>
             <email>nikolay.valchev@sap.com</email>
-            <organization>${organization.name}</organization>
-            <organizationUrl>${organization.url}</organizationUrl>
+            <organization>${project.organization.name}</organization>
+            <organizationUrl>${project.organization.url}</organizationUrl>
         </developer>
         <developer>
             <id>nictas</id>
-            <name>Alexander Tsvetkovv</name>
+            <name>Alexander Tsvetkov</name>
             <email>aleksandar.tsvetkov@sap.com</email>
-            <organization>${organization.name}</organization>
-            <organizationUrl>${organization.url}</organizationUrl>
+            <organization>${project.organization.name}</organization>
+            <organizationUrl>${project.organization.url}</organizationUrl>
         </developer>
         <developer>
             <id>enchobelezirev</id>
             <name>Encho Belezirev</name>
             <email>encho.belezirev@sap.com</email>
-            <organization>${organization.name}</organization>
-            <organizationUrl>${organization.url}</organizationUrl>
+            <organization>${project.organization.name}</organization>
+            <organizationUrl>${project.organization.url}</organizationUrl>
+        </developer>
+        <developer>
+            <id>ddonchev</id>
+            <name>Dimitar Donchev</name>
+            <email>dimitar.donchev@sap.com</email>
+            <organization>${project.organization.name}</organization>
+            <organizationUrl>${project.organization.url}</organizationUrl>
+        </developer>
+        <developer>
+            <id>DenitsaKostova</id>
+            <name>Denitsa Petrova</name>
+            <email>denitsa.petrova@sap.com</email>
+            <organization>${project.organization.name}</organization>
+            <organizationUrl>${project.organization.url}</organizationUrl>
+        </developer>
+        <developer>
+            <id>ttsokov</id>
+            <name>Tsvetan Tsokov</name>
+            <email>tsvetan.tsokov@sap.com</email>
+            <organization>${project.organization.name}</organization>
+            <organizationUrl>${project.organization.url}</organizationUrl>
+        </developer>
+        <developer>
+            <id>monochronique</id>
+            <name>Mihail Tsonev</name>
+            <email>mihail.tsonev@sap.com</email>
+            <organization>${project.organization.name}</organization>
+            <organizationUrl>${project.organization.url}</organizationUrl>
+        </developer>
+        <developer>
+            <id>boyan-velinov</id>
+            <name>Boyan Velinov</name>
+            <email>boyan.velinov@sap.com</email>
+            <organization>${project.organization.name}</organization>
+            <organizationUrl>${project.organization.url}</organizationUrl>
+        </developer>
+        <developer>
+            <id>KristianShishoev</id>
+            <name>Kristian Shishoev</name>
+            <email>kristian.shishoev@sap.com</email>
+            <organization>${project.organization.name}</organization>
+            <organizationUrl>${project.organization.url}</organizationUrl>
         </developer>
     </developers>
 
@@ -153,6 +200,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
                 <configuration>
                     <skip>false</skip>
                 </configuration>


### PR DESCRIPTION
There were 2 kinds of getter methods in CloudControllerClientImpl based
on their behaviour when the entity they were supposed to return did not
exist - ones that threw exceptions (either CloudFoundryExceptions or
IllegalArgumentExceptions) and others that simply returned null.

This commit fixes that inconsistency and now all of these methods throw
a CloudFoundryException in such cases.