### PR TITLE
Add race condition resilience to multiple request client calls

### DIFF
--- a/cloudfoundry-client-lib/pom.xml
+++ b/cloudfoundry-client-lib/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.lm.sl</groupId>
         <artifactId>cf-java-client</artifactId>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>cf-java-client</artifactId>
     <packaging>pom</packaging>
     <name>Cloud Foundry Java Client Parent</name>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
     <description>SAP fork of CF Java Client</description>
     <url>https://github.com/SAP/cf-java-client-sap</url>
 


### PR DESCRIPTION
Return null rather than throw a CloudOperationException when an application is no longer started by the time it's stats are being queried.

Return null rather than throw a CloudOperationException when an application is no longer found during it's processing.