### PR TITLE
Add race condition resilience to multiple request client calls

### DIFF
--- a/cloudfoundry-client-lib/pom.xml
+++ b/cloudfoundry-client-lib/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.lm.sl</groupId>
         <artifactId>cf-java-client</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1</version>
     </parent>
 
     <properties>

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerRestClientImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerRestClientImpl.java
@@ -112,6 +112,7 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -2147,9 +2148,11 @@ public class CloudControllerRestClientImpl implements CloudControllerRestClient 
         List<InstanceStats> instanceList = new ArrayList<InstanceStats>();
         if (appState.equals(CloudApplication.AppState.STARTED)) {
             Map<String, Object> respMap = getInstanceInfoForApp(appId, "stats");
-            for (String instanceId : respMap.keySet()) {
-                InstanceStats instanceStats = new InstanceStats(instanceId, (Map<String, Object>) respMap.get(instanceId));
-                instanceList.add(instanceStats);
+            if (!CollectionUtils.isEmpty(respMap)) {
+                for (String instanceId : respMap.keySet()) {
+                    InstanceStats instanceStats = new InstanceStats(instanceId, (Map<String, Object>) respMap.get(instanceId));
+                    instanceList.add(instanceStats);
+                }
             }
         }
         return new ApplicationStats(instanceList);
@@ -2642,11 +2645,20 @@ public class CloudControllerRestClientImpl implements CloudControllerRestClient 
     }
 
     private Map<String, Object> getInstanceInfoForApp(UUID appId, String path) {
-        String url = getUrl("/v2/apps/{guid}/" + path);
-        Map<String, Object> urlVars = new HashMap<String, Object>();
-        urlVars.put("guid", appId);
-        String resp = getRestTemplate().getForObject(url, String.class, urlVars);
-        return JsonUtil.convertJsonToMap(resp);
+        try {
+            String url = getUrl("/v2/apps/{guid}/" + path);
+            Map<String, Object> urlVars = new HashMap<String, Object>();
+            urlVars.put("guid", appId);
+            String resp = getRestTemplate().getForObject(url, String.class, urlVars);
+            return JsonUtil.convertJsonToMap(resp);
+        } catch (CloudOperationException e) {
+            if (HttpStatus.BAD_REQUEST.equals(e.getStatusCode())) {
+                // Application has been stopped before we could get the instance info
+                logger.warn(e.getMessage(), e);
+                return null;
+            }
+            throw e;
+        }
     }
 
     private CloudResources getKnownRemoteResources(ApplicationArchive archive) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>cf-java-client</artifactId>
     <packaging>pom</packaging>
     <name>Cloud Foundry Java Client Parent</name>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <description>SAP fork of CF Java Client</description>
     <url>https://github.com/SAP/cf-java-client-sap</url>
 


### PR DESCRIPTION
Return null rather than throw a CloudOperationException when an application is no longer started by the time it's stats are being queried.

Return null rather than throw a CloudOperationException when an application is no longer found during it's processing.