### PR TITLE
enhance createServiceKey to return object

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudControllerClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudControllerClient.java
@@ -295,7 +295,7 @@ public interface CloudControllerClient {
      * @param parameters parameters of service-key
      * @return
      */
-    void createServiceKey(String serviceName, String serviceKeyName, Map<String, Object> parameters);
+    CloudServiceKey createServiceKey(String serviceName, String serviceKeyName, Map<String, Object> parameters);
 
     /**
      * Create a space with the specified name

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudControllerClientImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/CloudControllerClientImpl.java
@@ -296,8 +296,8 @@ public class CloudControllerClientImpl implements CloudControllerClient {
     }
 
     @Override
-    public void createServiceKey(String serviceName, String serviceKeyName, Map<String, Object> parameters) {
-        cc.createServiceKey(serviceName, serviceKeyName, parameters);
+    public CloudServiceKey createServiceKey(String serviceName, String serviceKeyName, Map<String, Object> parameters) {
+        return cc.createServiceKey(serviceName, serviceKeyName, parameters);
     }
 
     @Override

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerRestClient.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerRestClient.java
@@ -110,7 +110,7 @@ public interface CloudControllerRestClient {
 
     void createServiceBroker(CloudServiceBroker serviceBroker);
 
-    void createServiceKey(String service, String serviceKey, Map<String, Object> parameters);
+    CloudServiceKey createServiceKey(String service, String serviceKey, Map<String, Object> parameters);
 
     void createSpace(String spaceName);
 


### PR DESCRIPTION
Enhance the createServiceKey method to return a CloudServiceKey object on
success. This saves extra calls when you need to retrieve things such as
the credentials.