### PR TITLE
Fail-safe deletion of application

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerRestClientImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerRestClientImpl.java
@@ -469,7 +469,10 @@ public class CloudControllerRestClientImpl implements CloudControllerRestClient 
 
     @Override
     public void deleteApplication(String applicationName) {
-        UUID applicationGuid = getRequiredApplicationGuid(applicationName);
+        UUID applicationGuid = getApplicationGuid(applicationName);
+        if (applicationGuid == null) {
+            return;
+        }
         List<UUID> serviceBindingGuids = getServiceBindingGuids(applicationGuid);
         for (UUID serviceBindingGuid : serviceBindingGuids) {
             doUnbindService(serviceBindingGuid);


### PR DESCRIPTION
If the application is deleted for some reason and we attempt to delete this application the deploy service fails with:
Error deleting application "anatz-blue": Controller operation failed: 404 Not Found: Application anatz-blue not found.
Make the deletion fail-safe.