### PR TITLE
Add type property to CloudService

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/adapters/RawCloudService.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/adapters/RawCloudService.java
@@ -3,6 +3,7 @@ package org.cloudfoundry.client.lib.adapters;
 import java.util.Optional;
 
 import org.cloudfoundry.client.lib.domain.CloudService;
+import org.cloudfoundry.client.lib.domain.ServiceInstanceType;
 import org.cloudfoundry.client.lib.domain.ImmutableCloudService;
 import org.cloudfoundry.client.lib.domain.annotation.Nullable;
 import org.cloudfoundry.client.v2.Resource;
@@ -32,6 +33,7 @@ public abstract class RawCloudService extends RawCloudEntity<CloudService> {
                                     .name(entity.getName())
                                     .plan(parsePlan(getServicePlanResource()))
                                     .label(parseLabel(getServiceResource()))
+                                    .type(ServiceInstanceType.valueOfWithDefault(entity.getType()))
                                     .tags(entity.getTags())
                                     .credentials(entity.getCredentials())
                                     .build();

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudService.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/CloudService.java
@@ -30,8 +30,11 @@ public interface CloudService extends CloudEntity, Derivable<CloudService> {
 
     List<String> getTags();
 
+    @Nullable
+    ServiceInstanceType getType();
+
     default boolean isUserProvided() {
-        return getPlan() == null && getProvider() == null && getVersion() == null;
+        return getType() != null && getType().equals(ServiceInstanceType.USER_PROVIDED);
     }
 
     @Override

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/ServiceInstanceType.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/domain/ServiceInstanceType.java
@@ -1,0 +1,32 @@
+package org.cloudfoundry.client.lib.domain;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+
+public enum ServiceInstanceType {
+
+    USER_PROVIDED("user_provided_service_instance"),
+    MANAGED("managed_service_instance");
+
+    @JsonValue
+    private final String type;
+
+    ServiceInstanceType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public String toString() {
+        return type;
+    }
+
+    public static ServiceInstanceType valueOfWithDefault(String type) {
+        return Arrays.asList(ServiceInstanceType.values())
+                     .stream()
+                     .filter(serviceInstanceType -> serviceInstanceType.toString()
+                                                                       .equalsIgnoreCase(type))
+                     .findFirst()
+                     .orElse(MANAGED);
+    }
+}

--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerRestClientImpl.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/rest/CloudControllerRestClientImpl.java
@@ -88,6 +88,7 @@ import org.cloudfoundry.client.lib.domain.CloudServiceInstance;
 import org.cloudfoundry.client.lib.domain.CloudServiceKey;
 import org.cloudfoundry.client.lib.domain.CloudServiceOffering;
 import org.cloudfoundry.client.lib.domain.CloudServicePlan;
+import org.cloudfoundry.client.lib.domain.ServiceInstanceType;
 import org.cloudfoundry.client.lib.domain.CloudSpace;
 import org.cloudfoundry.client.lib.domain.CloudStack;
 import org.cloudfoundry.client.lib.domain.CloudTask;
@@ -173,7 +174,6 @@ import org.cloudfoundry.client.v2.serviceplans.ListServicePlansRequest;
 import org.cloudfoundry.client.v2.serviceplans.ServicePlanEntity;
 import org.cloudfoundry.client.v2.serviceplans.UpdateServicePlanRequest;
 import org.cloudfoundry.client.v2.services.GetServiceRequest;
-import org.cloudfoundry.client.v2.services.ListServicesRequest;
 import org.cloudfoundry.client.v2.services.ServiceEntity;
 import org.cloudfoundry.client.v2.shareddomains.ListSharedDomainsRequest;
 import org.cloudfoundry.client.v2.shareddomains.SharedDomainEntity;
@@ -251,7 +251,6 @@ public class CloudControllerRestClientImpl implements CloudControllerRestClient 
     private static final String MESSAGE_FEATURE_IS_NOT_YET_IMPLEMENTED = "Feature is not yet implemented.";
     private static final String DEFAULT_HOST_DOMAIN_SEPARATOR = "\\.";
     private static final String DEFAULT_PATH_SEPARATOR = "/";
-    private static final String USER_PROVIDED_SERVICE_INSTANCE_TYPE = "user_provided_service_instance";
     private static final long JOB_POLLING_PERIOD = TimeUnit.SECONDS.toMillis(5);
 
     private CloudCredentials credentials;
@@ -1769,7 +1768,8 @@ public class CloudControllerRestClientImpl implements CloudControllerRestClient 
     }
 
     private boolean isUserProvided(UnionServiceInstanceEntity serviceInstance) {
-        return USER_PROVIDED_SERVICE_INSTANCE_TYPE.equals(serviceInstance.getType());
+        return ServiceInstanceType.valueOfWithDefault(serviceInstance.getType())
+                               .equals(ServiceInstanceType.USER_PROVIDED);
     }
 
     private List<UUID> getServiceBindingGuids(CloudService service) {

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/adapters/RawCloudServiceInstanceTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/adapters/RawCloudServiceInstanceTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 public class RawCloudServiceInstanceTest {
 
     private static final String NAME = "foo";
-    private static final String TYPE = "user_provided_service_instance";
     private static final String DASHBOARD_URL = "/dashboard";
     private static final Map<String, Object> CREDENTIALS = buildTestCredentials();
     private static final CloudService SERVICE = buildTestService();
@@ -37,7 +36,7 @@ public class RawCloudServiceInstanceTest {
                                             .dashboardUrl(DASHBOARD_URL)
                                             .bindings(BINDINGS)
                                             .name(NAME)
-                                            .type(TYPE)
+                                            .type("user_provided_service_instance")
                                             .service(SERVICE)
                                             .credentials(CREDENTIALS)
                                             .build();
@@ -61,7 +60,7 @@ public class RawCloudServiceInstanceTest {
     private static UnionServiceInstanceEntity buildTestEntity() {
         return UnionServiceInstanceEntity.builder()
                                          .name(NAME)
-                                         .type(TYPE)
+                                         .type("user_provided_service_instance")
                                          .dashboardUrl(DASHBOARD_URL)
                                          .credentials(CREDENTIALS)
                                          .build();

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/adapters/RawCloudServiceTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/adapters/RawCloudServiceTest.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.client.lib.adapters;
 
 import org.cloudfoundry.client.lib.domain.CloudService;
+import org.cloudfoundry.client.lib.domain.ServiceInstanceType;
 import org.cloudfoundry.client.lib.domain.ImmutableCloudService;
 import org.cloudfoundry.client.v2.Resource;
 import org.cloudfoundry.client.v2.serviceinstances.UnionServiceInstanceEntity;
@@ -40,6 +41,7 @@ public class RawCloudServiceTest {
                                     .name(NAME)
                                     .plan(PLAN_NAME)
                                     .label(OFFERING_NAME)
+                                    .type(ServiceInstanceType.MANAGED)
                                     .credentials(CREDENTIALS)
                                     .tags(TAGS)
                                     .build();
@@ -49,6 +51,7 @@ public class RawCloudServiceTest {
         return ImmutableCloudService.builder()
                                     .metadata(RawCloudEntityTest.EXPECTED_METADATA)
                                     .name(NAME)
+                                    .type(ServiceInstanceType.USER_PROVIDED)
                                     .credentials(CREDENTIALS)
                                     .tags(TAGS)
                                     .build();
@@ -64,7 +67,7 @@ public class RawCloudServiceTest {
 
     private static RawCloudService buildRawUserProvidedService() {
         return ImmutableRawCloudService.builder()
-                                       .resource(buildTestResource())
+                                       .resource(buildUserProvidedTestResource())
                                        .build();
     }
 
@@ -75,9 +78,26 @@ public class RawCloudServiceTest {
                                            .build();
     }
 
+    private static Resource<UnionServiceInstanceEntity> buildUserProvidedTestResource() {
+        return UnionServiceInstanceResource.builder()
+                                           .metadata(RawCloudEntityTest.METADATA)
+                                           .entity(buildUserProvidedTestEntity())
+                                           .build();
+    }
+
     private static UnionServiceInstanceEntity buildTestEntity() {
         return UnionServiceInstanceEntity.builder()
                                          .name(NAME)
+                                         .type("managed_service_instance")
+                                         .credentials(CREDENTIALS)
+                                         .addAllTags(TAGS)
+                                         .build();
+    }
+
+    private static UnionServiceInstanceEntity buildUserProvidedTestEntity() {
+        return UnionServiceInstanceEntity.builder()
+                                         .name(NAME)
+                                         .type("user_provided_service_instance")
                                          .credentials(CREDENTIALS)
                                          .addAllTags(TAGS)
                                          .build();


### PR DESCRIPTION
When building the CloudService immutable objects, set the type from the
entity. Refactor the 'isUserProvided()' method to check against the new
'type' property. JIRA: LMCROSSITXSADEPLOY-1746