### PR TITLE
Fix retrieval of application environments

### DIFF
--- a/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/adapters/RawCloudApplication.java
+++ b/cloudfoundry-client-lib/src/main/java/org/cloudfoundry/client/lib/adapters/RawCloudApplication.java
@@ -43,9 +43,11 @@ public abstract class RawCloudApplication extends RawCloudEntity<CloudApplicatio
 
     @Override
     public CloudApplication derive() {
+        Resource<ApplicationEntity> resource = getResource();
+        ApplicationEntity entity = resource.getEntity();
         SummaryApplicationResponse summary = getSummary();
         return ImmutableCloudApplication.builder()
-                                        .metadata(parseResourceMetadata(getResource()))
+                                        .metadata(parseResourceMetadata(resource))
                                         .name(summary.getName())
                                         .memory(summary.getMemory())
                                         .uris(toUrlStrings(summary.getRoutes()))
@@ -57,7 +59,7 @@ public abstract class RawCloudApplication extends RawCloudEntity<CloudApplicatio
                                         .packageState(parsePackageState(summary.getPackageState()))
                                         .stagingError(summary.getStagingFailedDescription())
                                         .services(getNames(summary.getServices()))
-                                        .env(parseEnv(summary.getEnvironmentJsons()))
+                                        .env(parseEnv(entity.getEnvironmentJsons()))
                                         .space(getSpace().derive())
                                         .build();
     }

--- a/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/adapters/RawCloudApplicationTest.java
+++ b/cloudfoundry-client-lib/src/test/java/org/cloudfoundry/client/lib/adapters/RawCloudApplicationTest.java
@@ -161,12 +161,7 @@ public class RawCloudApplicationTest {
     }
 
     private static RawCloudApplication buildRawApplicationWithoutEnvironment() {
-        SummaryApplicationResponse summary = buildApplicationSummary();
-        SummaryApplicationResponse summaryWithoutEnvironment = SummaryApplicationResponse.builder()
-                                                                                         .from(summary)
-                                                                                         .environmentJsons(null)
-                                                                                         .build();
-        return buildRawApplication(summaryWithoutEnvironment);
+        return buildRawApplication(buildApplicationResourceWithoutEnvironment(), buildApplicationSummary());
     }
 
     private static RawCloudApplication buildRawApplicationWithoutDockerInfo() {
@@ -176,7 +171,7 @@ public class RawCloudApplicationTest {
                                                                                         .dockerImage(null)
                                                                                         .dockerCredentials(null)
                                                                                         .build();
-        return buildRawApplication(summaryWithoutDockerInfo);
+        return buildRawApplication(buildApplicationResource(), summaryWithoutDockerInfo);
     }
 
     private static RawCloudApplication buildRawApplicationWithoutDockerCredentials() {
@@ -185,16 +180,17 @@ public class RawCloudApplicationTest {
                                                                                                .from(summary)
                                                                                                .dockerCredentials(null)
                                                                                                .build();
-        return buildRawApplication(summaryWithoutDockerCredentials);
+        return buildRawApplication(buildApplicationResource(), summaryWithoutDockerCredentials);
     }
 
     private static RawCloudApplication buildRawApplication() {
-        return buildRawApplication(buildApplicationSummary());
+        return buildRawApplication(buildApplicationResource(), buildApplicationSummary());
     }
 
-    private static RawCloudApplication buildRawApplication(SummaryApplicationResponse summary) {
+    private static RawCloudApplication buildRawApplication(Resource<ApplicationEntity> applicationResource,
+                                                           SummaryApplicationResponse summary) {
         return ImmutableRawCloudApplication.builder()
-                                           .resource(buildApplicationResource())
+                                           .resource(applicationResource)
                                            .summary(summary)
                                            .stack(STACK)
                                            .space(SPACE)
@@ -202,8 +198,19 @@ public class RawCloudApplicationTest {
     }
 
     private static Resource<ApplicationEntity> buildApplicationResource() {
+        return buildApplicationResource(ENVIRONMENT);
+    }
+
+    private static Resource<ApplicationEntity> buildApplicationResourceWithoutEnvironment() {
+        return buildApplicationResource(null);
+    }
+
+    private static Resource<ApplicationEntity> buildApplicationResource(Map<String, Object> environmentJsons) {
         return ApplicationResource.builder()
                                   .metadata(RawCloudEntityTest.METADATA)
+                                  .entity(ApplicationEntity.builder()
+                                                           .environmentJsons(environmentJsons)
+                                                           .build())
                                   .build();
     }
 
@@ -224,7 +231,6 @@ public class RawCloudApplicationTest {
                                          .enableSsh(SSH_ENABLED)
                                          .dockerImage(DOCKER_IMAGE)
                                          .dockerCredentials(DOCKER_CREDENTIALS)
-                                         .environmentJsons(ENVIRONMENT)
                                          .command(COMMAND)
                                          .buildpack(BUILDPACK)
                                          .detectedBuildpack(DETECTED_BUILDPACK)


### PR DESCRIPTION
There's a bug in the Cloud Foundry controller where the summary endpoint sometimes returns an outdated application environment.