### PR TITLE
Make unbind operation safe for NPE

### DIFF
--- a/src/main/java/com/sap/cloudfoundry/client/facade/rest/CloudControllerRestClientImpl.java
+++ b/src/main/java/com/sap/cloudfoundry/client/facade/rest/CloudControllerRestClientImpl.java
@@ -2077,6 +2077,11 @@ public class CloudControllerRestClientImpl implements CloudControllerRestClient 
 
     private void doUnbindServiceInstance(UUID applicationGuid, UUID serviceInstanceGuid) {
         UUID serviceBindingGuid = getServiceBindingGuid(applicationGuid, serviceInstanceGuid);
+        if (serviceBindingGuid == null) {
+            throw new CloudOperationException(HttpStatus.NOT_FOUND,
+                                              "Not Found",
+                                              "Service binding between service with GUID " + serviceInstanceGuid + " and application with GUID " + applicationGuid + " not found.");
+        }
         doUnbindServiceInstance(serviceBindingGuid);
     }
 


### PR DESCRIPTION
Add null check in unbind operation call:
CloudControllerRestClientImpl.doUnbindServiceInstance

This prevents NPE when the binding between service and app
is already deleted. Instead meaningfull error message is send.

Jira: LMCROSSITXSADEPLOY-2325