### PR TITLE
Bump version of jackson library to 2.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <junit.version>5.8.2</junit.version>
         <junit.platform.version>1.8.2</junit.platform.version>
         <mockito.version>4.2.0</mockito.version>
-        <jackson.version>2.11.3</jackson.version>
+        <jackson.version>2.13.1</jackson.version>
         <spring.version>5.3.14</spring.version>
         <spring-security.version>5.6.0</spring-security.version>
         <commons-io.version>2.8.0</commons-io.version>


### PR DESCRIPTION
Due to white-source vulnerability - jackson version should be updated.