### PR TITLE
Bump OSS dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,18 +15,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.surefire.version>2.22.2</maven.surefire.version>
         <maven.failsafe.version>2.22.2</maven.failsafe.version>
-        <junit.version>5.9.2</junit.version>
-        <junit.platform.version>1.9.2</junit.platform.version>
+        <junit.version>5.10.2</junit.version>
+        <junit.platform.version>1.10.2</junit.platform.version>
         <mockito.version>4.11.0</mockito.version>
-        <jackson.version>2.16.1</jackson.version>
-        <jackson.databind.version>2.16.1</jackson.databind.version>
-        <spring.version>5.3.31</spring.version>
-        <spring-security.version>5.8.9</spring-security.version>
-        <commons-io.version>2.11.0</commons-io.version>
-        <immutables.version>2.8.8</immutables.version>
-        <cloudfoundry-client.version>5.10.0.RELEASE</cloudfoundry-client.version>
+        <jackson.version>2.17.0</jackson.version>
+        <jackson.databind.version>2.17.0</jackson.databind.version>
+        <spring.version>5.3.33</spring.version>
+        <spring-security.version>5.8.11</spring-security.version>
+        <commons-io.version>2.15.1</commons-io.version>
+        <immutables.version>2.10.1</immutables.version>
+        <cloudfoundry-client.version>5.12.1.RELEASE</cloudfoundry-client.version>
         <reactor-netty.version>1.0.39</reactor-netty.version>
-        <micrometer.version>1.10.4</micrometer.version>
+        <micrometer.version>1.12.4</micrometer.version>
     </properties>
 
     <organization>


### PR DESCRIPTION
* cloudfoundry-client to 5.12.1.RELEASE
* spring to 5.3.33
* spring-security to 5.8.11
* immutables to 2.10.1
* jackson to 2.17.0
* jackson.databind to 2.17.0
* micrometer to 1.12.4
* commons-io to 2.15.1
* junit to 5.10.2
* junit.platform to 1.10.2